### PR TITLE
fix: preferences directoy is now really created

### DIFF
--- a/tui/preferences.go
+++ b/tui/preferences.go
@@ -40,7 +40,7 @@ func LoadKeyStore(preferencePath string) (*KeyStore, error) {
 }
 
 func (k *KeyStore) Save() (err error) {
-	if os.Stat(path.Dir(k.preferencePath)); os.IsNotExist(err) {
+	if _, err := os.Stat(path.Dir(k.preferencePath)); os.IsNotExist(err) {
 		err = os.MkdirAll(path.Dir(k.preferencePath), 0755)
 		if err != nil {
 			return fmt.Errorf("failed to create preferences directory: %w", err)


### PR DESCRIPTION
Minor fix: the preferences directory wasn't really created when it did not exit due to a wrong `os.IsNotExist(err)` comparison