### PR TITLE
Include cmd/http/expr actions for preview/onquerychange

### DIFF
--- a/cmd/detail.go
+++ b/cmd/detail.go
@@ -47,7 +47,7 @@ func NewDetailCmd() *cobra.Command {
 				return &types.Page{
 					Title: title,
 					Type:  "detail",
-					Preview: &types.TextOrCommandOrRequest{
+					Preview: &types.PreviewProvider{
 						Text: text,
 					},
 				}, nil

--- a/docs/types.md
+++ b/docs/types.md
@@ -107,6 +107,8 @@
 - `command`: [Command](#command)
 - `request`: [Request](#request)
 - `text`: string
+- `file`: string
+- `expression`: string
 - `__index`: any
 
 ## Form

--- a/internal/generators.go
+++ b/internal/generators.go
@@ -76,6 +76,23 @@ func NewStaticGenerator(reader io.Reader) PageGenerator {
 	}
 }
 
+func NewPageProviderGenerator(pageProvider *types.PageProvider) PageGenerator {
+	// TODO: Add Text/Static ?
+	if pageProvider.File != "" {
+		return NewFileGenerator(pageProvider.File)
+	} else if pageProvider.Command != nil {
+		return NewCommandGenerator(pageProvider.Command)
+	} else if pageProvider.Request != nil {
+		return NewRequestGenerator(pageProvider.Request)
+	} else if pageProvider.Expression != nil {
+		return NewRequestGenerator(pageProvider.Expression.Request())
+	} else {
+		return func() (*types.Page, error) {
+			return nil, fmt.Errorf("missing pageProvider")
+		}
+	}
+}
+
 func NewCommandGenerator(command *types.Command) PageGenerator {
 	return func() (*types.Page, error) {
 		output, err := command.Output(context.TODO())

--- a/internal/list.go
+++ b/internal/list.go
@@ -138,11 +138,7 @@ func NewList(page *types.Page) *List {
 			return ""
 		}
 
-		if item.Preview.Text != "" {
-			return item.Preview.Text
-		}
-
-		output, err := item.Preview.Command.Output(context.TODO())
+		output, err := item.Preview.Output(context.TODO())
 		if err != nil {
 			return err.Error()
 		}

--- a/internal/runner.go
+++ b/internal/runner.go
@@ -355,8 +355,8 @@ func (runner *CommandRunner) Update(msg tea.Msg) (Page, tea.Cmd) {
 			return runner, nil
 		}
 
-		queryCmd := RenderCommand(runner.currentPage.OnQueryChange, "${query}", msg.Query)
-		runner.Generator = NewCommandGenerator(queryCmd)
+		queryCmd := RenderPageProvider(runner.currentPage.OnQueryChange, "${query}", msg.Query)
+		runner.Generator = NewPageProviderGenerator(queryCmd)
 
 		return runner, tea.Sequence(runner.SetIsloading(true), runner.Refresh)
 	case types.Action:
@@ -494,10 +494,54 @@ func RenderAction(action types.Action, old, new string) types.Action {
 		action.Command = RenderCommand(action.Command, old, new)
 	}
 
+	if action.Request != nil {
+		action.Request = RenderRequest(action.Request, old, new)
+	}
+
+	if action.Expression != nil {
+		action.Expression = RenderExpression(action.Expression, old, new)
+	}
+
 	action.Target = strings.ReplaceAll(action.Target, old, url.QueryEscape(new))
 	action.Text = strings.ReplaceAll(action.Text, old, new)
 	action.Page = strings.ReplaceAll(action.Page, old, new)
 	return action
+}
+
+func RenderPreviewProvider(previewProvider *types.PreviewProvider, old, new string) *types.PreviewProvider {
+	if previewProvider.Text != "" {
+		previewProvider.Text = strings.ReplaceAll(previewProvider.Text, old, new)
+	} else if previewProvider.File != "" {
+		previewProvider.File = strings.ReplaceAll(previewProvider.File, old, new)
+	} else if previewProvider.Command != nil {
+		previewProvider.Command = RenderCommand(previewProvider.Command, old, new)
+	} else if previewProvider.Request != nil {
+		previewProvider.Request = RenderRequest(previewProvider.Request, old, new)
+	} else if previewProvider.Expression != nil {
+		previewProvider.Expression = RenderExpression(previewProvider.Expression, old, new)
+	}
+	return previewProvider
+}
+
+func RenderPageProvider(pageProvider *types.PageProvider, old, new string) *types.PageProvider {
+	if pageProvider.Text != "" {
+		pageProvider.Text = strings.ReplaceAll(pageProvider.Text, old, new)
+	} else if pageProvider.File != "" {
+		pageProvider.File = strings.ReplaceAll(pageProvider.File, old, new)
+	} else if pageProvider.Command != nil {
+		pageProvider.Command = RenderCommand(pageProvider.Command, old, new)
+	} else if pageProvider.Request != nil {
+		pageProvider.Request = RenderRequest(pageProvider.Request, old, new)
+	} else if pageProvider.Expression != nil {
+		pageProvider.Expression = RenderExpression(pageProvider.Expression, old, new)
+	}
+	return pageProvider
+}
+
+func RenderExpression(expression *types.Expression, old, new string) *types.Expression {
+	s := string(*expression)
+	rendered := types.Expression(strings.ReplaceAll(s, old, new))
+	return &rendered
 }
 
 func expandPage(page types.Page, base *url.URL) (*types.Page, error) {

--- a/schemas/page.schema.json
+++ b/schemas/page.schema.json
@@ -50,7 +50,7 @@
                     "type": "string"
                 },
                 "onQueryChange": {
-                    "$ref": "#/$defs/command"
+                    "$ref": "#/$defs/pageProvider"
                 },
                 "emptyView": {
                     "type": "object",
@@ -99,7 +99,7 @@
                 "type",
                 "preview"
             ],
-            "description": "A detail view displayign a preview and actions.",
+            "description": "A detail view displaying a preview and actions.",
             "properties": {
                 "type": {
                     "description": "The type of the response.",
@@ -709,6 +709,32 @@
                     "$ref": "#/$defs/request"
                 },
                 "text": {
+                    "type": "string"
+                },
+                "file": {
+                    "type": "string"
+                },
+                "expression": {
+                    "type": "string"
+                }
+            }
+        },
+        "pageProvider": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "$ref": "#/$defs/command"
+                },
+                "request": {
+                    "$ref": "#/$defs/request"
+                },
+                "text": {
+                    "type": "string"
+                },
+                "file": {
+                    "type": "string"
+                },
+                "expression": {
                     "type": "string"
                 }
             }

--- a/types/types.go
+++ b/types/types.go
@@ -34,13 +34,13 @@ type Page struct {
 	SubmitAction *Action `json:"submitAction,omitempty"`
 
 	// Detail page
-	Preview *TextOrCommandOrRequest `json:"preview,omitempty"`
+	Preview *PreviewProvider `json:"preview,omitempty"`
 
 	// List page
-	ShowPreview   bool       `json:"showPreview,omitempty"`
-	OnQueryChange *Command   `json:"onQueryChange,omitempty"`
-	EmptyView     *EmptyView `json:"emptyView,omitempty"`
-	Items         []ListItem `json:"items,omitempty"`
+	ShowPreview   bool          `json:"showPreview,omitempty"`
+	OnQueryChange *PageProvider `json:"onQueryChange,omitempty"`
+	EmptyView     *EmptyView    `json:"emptyView,omitempty"`
+	Items         []ListItem    `json:"items,omitempty"`
 }
 
 type EmptyView struct {
@@ -49,12 +49,12 @@ type EmptyView struct {
 }
 
 type ListItem struct {
-	Id          string                  `json:"id,omitempty"`
-	Title       string                  `json:"title"`
-	Subtitle    string                  `json:"subtitle,omitempty"`
-	Preview     *TextOrCommandOrRequest `json:"preview,omitempty"`
-	Accessories []string                `json:"accessories,omitempty"`
-	Actions     []Action                `json:"actions,omitempty"`
+	Id          string           `json:"id,omitempty"`
+	Title       string           `json:"title"`
+	Subtitle    string           `json:"subtitle,omitempty"`
+	Preview     *PreviewProvider `json:"preview,omitempty"`
+	Accessories []string         `json:"accessories,omitempty"`
+	Actions     []Action         `json:"actions,omitempty"`
 }
 
 type FormInputType string
@@ -249,11 +249,15 @@ func (b *Body) UnmarshalJSON(data []byte) error {
 	return errors.New("body must be a string or a map")
 }
 
-type TextOrCommandOrRequest struct {
-	Text    string   `json:"text,omitempty"`
-	Command *Command `json:"command,omitempty"`
-	Request *Request `json:"request,omitempty"`
+type PreviewProvider struct {
+	Text       string      `json:"text,omitempty"`
+	File       string      `json:"file,omitempty"`
+	Command    *Command    `json:"command,omitempty"`
+	Request    *Request    `json:"request,omitempty"`
+	Expression *Expression `json:"expression,omitempty"`
 }
+
+type PageProvider PreviewProvider
 
 type Command struct {
 	Name  string   `json:"name"`
@@ -336,4 +340,24 @@ func (c *Command) UnmarshalJSON(data []byte) error {
 	}
 
 	return fmt.Errorf("invalid command")
+}
+
+func (pp PreviewProvider) Output(ctx context.Context) ([]byte, error) {
+	if pp.Text != "" {
+		return []byte(pp.Text), nil
+	} else if pp.File != "" {
+		b, err := os.ReadFile(pp.File)
+		if err != nil {
+			return nil, err
+		}
+		return b, nil
+	} else if pp.Command != nil {
+		return pp.Command.Output(ctx)
+	} else if pp.Request != nil {
+		return pp.Request.Do(ctx)
+	} else if pp.Expression != nil {
+		return pp.Expression.Request().Do(ctx)
+	} else {
+		return nil, errors.New("invalid previewProvider")
+	}
 }

--- a/types/typescript/index.ts
+++ b/types/typescript/index.ts
@@ -8,6 +8,28 @@ export type Command =
       input?: string;
       dir?: string;
     };
+export type Request =
+  | string
+  | {
+      /**
+       * The URL to request.
+       */
+      url: string;
+      /**
+       * The HTTP method to use.
+       */
+      method?: string;
+      /**
+       * The headers to send.
+       */
+      headers?: {
+        [k: string]: string;
+      };
+      /**
+       * The body to send.
+       */
+      body?: string;
+    };
 export type Action =
   | {
       /**
@@ -307,28 +329,6 @@ export type Input =
       default?: string;
     };
 export type OnSuccess = "copy" | "paste" | "open" | "reload";
-export type Request =
-  | string
-  | {
-      /**
-       * The URL to request.
-       */
-      url: string;
-      /**
-       * The HTTP method to use.
-       */
-      method?: string;
-      /**
-       * The headers to send.
-       */
-      headers?: {
-        [k: string]: string;
-      };
-      /**
-       * The body to send.
-       */
-      body?: string;
-    };
 
 export interface List {
   /**
@@ -339,7 +339,7 @@ export interface List {
    * The title of the page.
    */
   title?: string;
-  onQueryChange?: Command;
+  onQueryChange?: PageProvider;
   emptyView?: {
     /**
      * The text to show when the list is empty.
@@ -355,6 +355,14 @@ export interface List {
    */
   showPreview?: boolean;
   items?: Listitem[] | null;
+}
+export interface PageProvider {
+  command?: Command;
+  request?: Request;
+  text?: string;
+  file?: string;
+  expression?: string;
+  [k: string]: unknown;
 }
 export interface Listitem {
   /**
@@ -383,10 +391,12 @@ export interface Preview {
   command?: Command;
   request?: Request;
   text?: string;
+  file?: string;
+  expression?: string;
   [k: string]: unknown;
 }
 /**
- * A detail view displayign a preview and actions.
+ * A detail view displaying a preview and actions.
  */
 export interface Detail {
   /**

--- a/types/typescript/package-lock.json
+++ b/types/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sunbeam-types",
-    "version": "0.15.0",
+    "version": "0.16.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sunbeam-types",
-            "version": "0.15.0",
+            "version": "0.16.0",
             "devDependencies": {
                 "json-schema-to-typescript": "^12.0.0",
                 "typescript": "^5.1.3",

--- a/types/typescript/package.json
+++ b/types/typescript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sunbeam-types",
-    "version": "0.15.0",
+    "version": "0.16.0",
     "description": "Types for sunbeam",
     "homepage": "https://pomdtr.github.io/sunbeam",
     "repository": {


### PR DESCRIPTION
I replace TextOrCommandOrRequest with PreviewProvider and PageProvider.

At the moment they are the same but it can change in the future.

- PreviewProvider can be a text, file, command, http endpoint, val.town expression
- PageProvider can be file, command, http, val.town expression. (Text did not make sense and likely messy)

TODO (a different PR)
- PreviewProvider/PageProvider should be "rendered" to replace any `${query}` / `${env}`