### PR TITLE
goreleaser: add arch user repository support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          AUR_KEY: ${{ secrets.AUR_KEY }}
           # Your GoReleaser Pro key, if you are using the 'goreleaser-pro'
           # distribution:
           # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -67,3 +67,29 @@ scoop:
   homepage: https://pomdtr.github.io/sunbeam
   description: Generate powerful UIs from simple scripts written in any language.
   license: MIT
+aurs:
+  - name: sunbeam-bin
+    homepage: https://pomdtr.github.io/sunbeam
+    description: Generate powerful UIs from simple scripts written in any language.
+    maintainers:
+      - 'Achille Lacoin  <achille@deta.sh>'
+    license: MIT
+    # IMPORTANT: the key must not be password-protected.
+    private_key: '{{ .Env.AUR_KEY }}'
+    git_url: 'ssh://aur@aur.archlinux.org/sunbeam-bin.git'
+    conflicts:
+      - sunbeam
+    package: |-
+      # bin
+      install -Dm755 "./sunbeam" "${pkgdir}/usr/bin/sunbeam"
+
+      # license
+      install -Dm644 "./LICENSE-MIT" "${pkgdir}/usr/share/licenses/sunbeam/LICENSE"
+
+      # completions
+      mkdir -p "${pkgdir}/usr/share/bash-completion/completions/"
+      mkdir -p "${pkgdir}/usr/share/zsh/site-functions/"
+      mkdir -p "${pkgdir}/usr/share/fish/vendor_completions.d/"
+      install -Dm644 "./completions/sunbeam.bash" "${pkgdir}/usr/share/bash-completion/completions/sunbeam"
+      install -Dm644 "./completions/sunbeam.zsh" "${pkgdir}/usr/share/zsh/site-functions/_sunbeam"
+      install -Dm644 "./completions/sunbeam.fish" "${pkgdir}/usr/share/fish/vendor_completions.d/sunbeam.fish"


### PR DESCRIPTION
I really dig using Arch User Repository (AUR) for handling external software, which is the reason behind this PR.

You will need to [create an AUR account](https://aur.archlinux.org/register) and add the corresponding private key of the public key that you used during sign-up to GitHub secrets. I've never used `goreleaser` before, so I hope the patch is not too far away from being correct.

Sunbeam is a super cool piece of software, thanks for creating it!