### PR TITLE
fix typos

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -24,7 +24,7 @@ You can write command using any language. If you want to distribute your command
 Here are some suggestions if you don't know what language to use:
 
 - Bash is already installed on most systems. Sunbeam provides multiple commands to help you write bash commands. You can use the `sunbeam query` command to generate/manipulate JSON objects.
-- If you are more confortable with javascript/typescript, take a look at [deno](https://deno.land/). Types are available both on [npm](https://npmjs.com/package/sunbeam-types).
+- If you are more comfortable with javascript/typescript, take a look at [deno](https://deno.land/). Types are available both on [npm](https://npmjs.com/package/sunbeam-types).
 
 ## Distributing Commands
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -15,8 +15,8 @@ You can configure the appearance of sunbeam by setting the following environment
 
 - `SUNBEAM_HEIGHT`: The maximum height of the sunbeam window, in lines. Defaults to `0` (full-height).
 - `SUNBEAM_WIDTH`: The maximum width of the sunbeam window, in characters. Defaults to `0` (full-width).
-- `SUNBEAM_BORDER`: Wether to display a border around the window. Defaults to `false`.
-- `SUNBEAM_FULLSCREEN`: Wether to display the window in fullscreen. Defaults to `false`.
+- `SUNBEAM_BORDER`: Whether to display a border around the window. Defaults to `false`.
+- `SUNBEAM_FULLSCREEN`: Whether to display the window in fullscreen. Defaults to `false`.
 
 You can also set these options using the `--height` and `--padding` flags.
 


### PR DESCRIPTION
found via `codespell`