### PR TITLE
Update links to scripts in docs

### DIFF
--- a/docs/examples/devdocs/README.md
+++ b/docs/examples/devdocs/README.md
@@ -8,7 +8,7 @@
 ## Install
 
 ```bash
-curl -L https://raw.githubusercontent.com/pomdtr/sunbeam/main/docs/examples/devdocs/devdocs.sh > ~/.local/bin/sunbeam-devdocs
+curl -L https://raw.githubusercontent.com/pomdtr/sunbeam/main/docs/examples/devdocs/devdocs.bash > ~/.local/bin/sunbeam-devdocs
 chmod +x ~/.local/bin/sunbeam-devdocs
 ```
 

--- a/docs/examples/github/README.md
+++ b/docs/examples/github/README.md
@@ -9,7 +9,7 @@
 ## Install
 
 ```bash
-curl -L https://raw.githubusercontent.com/pomdtr/sunbeam/main/docs/examples/github/github.sh > ~/.local/bin/sunbeam-gh
+curl -L https://raw.githubusercontent.com/pomdtr/sunbeam/main/docs/examples/github/github.bash > ~/.local/bin/sunbeam-gh
 chmod +x ~/.local/bin/sunbeam-gh
 ```
 

--- a/docs/examples/tldr/README.md
+++ b/docs/examples/tldr/README.md
@@ -7,7 +7,7 @@
 ## Install
 
 ```bash
-curl -L https://raw.githubusercontent.com/pomdtr/sunbeam/main/docs/examples/tldr/tldr.sh > ~/.local/bin/sunbeam-tldr
+curl -L https://raw.githubusercontent.com/pomdtr/sunbeam/main/docs/examples/tldr/tldr.bash > ~/.local/bin/sunbeam-tldr
 chmod +x ~/.local/bin/sunbeam-tldr
 ```
 


### PR DESCRIPTION
Fix links in the docs/examples from `sh` to `bash`