### PR TITLE
Allow looping through actions when there are no items in the list

### DIFF
--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -347,7 +347,7 @@ func (c *List) Update(msg tea.Msg) (Page, tea.Cmd) {
 	oldSelection := c.filter.Selection()
 	newSelection := filter.Selection()
 	if newSelection == nil {
-		c.statusBar.SetActions(c.Actions...)
+		c.statusBar.SetActionsNoSelection(c.Actions...)
 		if c.showDetail {
 			c.updateViewport(sunbeam.ListItemDetail{})
 		}

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -290,7 +290,10 @@ func (c *List) Update(msg tea.Msg) (Page, tea.Cmd) {
 			}
 
 			selection, ok := c.Selection()
-			if !ok || len(selection.Actions) == 0 {
+			if ok && len(selection.Actions) < 2 {
+				break
+			}
+			if !ok && len(c.Actions) < 2 {
 				break
 			}
 

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -41,6 +41,13 @@ func NewStatusBar(actions ...sunbeam.Action) StatusBar {
 	}
 }
 
+func (c *StatusBar) SetActionsNoSelection(actions ...sunbeam.Action) {
+	// this is called all the time to set the action for no-selection
+	// we want to keep the current expanded and cursor status rather than updating them
+	c.actions = actions
+	c.filtered = actions
+}
+
 func (c *StatusBar) SetActions(actions ...sunbeam.Action) {
 	c.expanded = false
 	c.cursor = 0


### PR DESCRIPTION
Fixes #105 

I believe that the issue was both:
- when we capture key presses on `tab` when there is no selection
- and the fact that we call `SetActions` all the time in `Update()` when `newSelection == nil`