### PR TITLE
Update CI Lint version to fix failing action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,6 @@ jobs:
           go-version: "1.21"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6.1
         with:
           args: --timeout=5m


### PR DESCRIPTION
GH actions are currently failing because the old output format is no longer supported