### PR TITLE
Reformat `installation.md`

### DIFF
--- a/www/docs/user-guide/installation.md
+++ b/www/docs/user-guide/installation.md
@@ -1,21 +1,34 @@
 # Installation
 
-You can use a package manager
+## Package Manager
+
+### Homebrew
 
 ```bash
 brew install pomdtr/tap/sunbeam
+```
 
-# as a nix flake
+### Nix
+
+```bash
 nix shell github:pomdtr/sunbeam --command sunbeam
+```
 
-# arch linux (btw)
+### Yay (Arch Linux, btw)
+
+```bash
 yay -S sunbeam-bin
+```
 
-# from source
+## From Source
+
+```bash
 go install github.com/pomdtr/sunbeam@main
 ```
 
-or use binaries / packages from the [releases page](https://github.com/pomdtr/sunbeam/releases/latest).
+## GitHub Releases
+
+Alternatively, use binaries / packages from the [releases page](https://github.com/pomdtr/sunbeam/releases/latest).
 
 ## Completions
 


### PR DESCRIPTION
When following the installation docs, I really want to just copy the appropriate install command for my system. Since the code block currently contains *all* of the various install commands, this was a little clunky.

Obviously super minor, but thought this might be helpful!
Thanks!